### PR TITLE
use elm-mode to support indentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,674 @@
-Copyright 2016 The Alpaca Community
+                     GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+                            Preamble
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/alpaca-font-lock.el
+++ b/alpaca-font-lock.el
@@ -1,0 +1,287 @@
+;;; alpaca-font-lock.el --- Font locking module for Alpaca mode.
+
+;; Copyright (C) 2013, 2014 Joseph Collard
+;; Copyright (C) 2015 Bogdan Popa
+;; Copyright (C) 2017 The Alpaca Community
+
+;; Authors: Joseph Collard
+;; URL: https://github.com/jcollard/elm-mode
+
+;; Authors: Alpaca Community
+;; URL: https://github.com/alpaca-lang/alpaca-mode
+
+;; This file was adapted from `elm-indent.el'
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Code:
+(require 'font-lock)
+(require 'rx)
+
+(defgroup alpaca-font-lock nil
+  "Font locking for Alpaca code."
+  :group 'faces)
+
+(defface alpaca-font-lock-operators
+  '((t :inherit font-lock-builtin-face))
+  "The default face used to highlight operators inside expressions."
+  :group 'alpaca-font-lock)
+
+(defcustom alpaca-font-lock-operators-face 'alpaca-font-lock-operators
+  "The face used to highlight operators inside expressions.
+To disable this highlighting, set this to nil."
+  :type '(choice (const nil)
+                 face)
+  :group 'alpaca-font-lock)
+
+(defface alpaca-font-lock-multiline-list-delimiters
+  '((t :inherit font-lock-keyword-face))
+  "The default face used to highlight brackets and commas in multiline lists."
+  :group 'alpaca-font-lock)
+
+(defcustom alpaca-font-lock-multiline-list-delimiters-face 'alpaca-font-lock-multiline-list-delimiters
+  "The face used to highlight brackets and commas in multilist lists.
+To disable this highlighting, set this to nil."
+  :type '(choice (const nil)
+                 face)
+  :group 'alpaca-font-lock)
+
+(defconst alpaca--keywords
+  '("module" "export" "export_type" "let" "in"
+    "type" "match" "with"
+    "beam"
+    "spawn" "send" "receive" "after"
+    "test"
+    "error" "exit" "throw"
+    "true" "false"
+    "unit" "size" "end" "sign"
+    "big" "little" "native" "utf8")
+  "Reserved keywords.")
+
+(defconst alpaca--regexp-keywords
+  (concat (regexp-opt alpaca--keywords 'words) "[^']")
+  "A regular expression representing the reserved keywords.")
+
+(defconst alpaca--font-lock-keywords
+  (cons alpaca--regexp-keywords font-lock-keyword-face)
+  "Highlighting for keywords.")
+
+(defun alpaca--syntax-stringify ()
+  "Syntax propertize triple quoted strings."
+  (let* ((ppss (save-excursion
+                 (backward-char 3)
+                 (syntax-ppss)))
+         (string-started (and (not (nth 4 ppss)) (nth 8 ppss)))
+         (quote-starting-pos (- (point) 3))
+         (quote-ending-pos (point)))
+    (if (not string-started)
+        (put-text-property quote-starting-pos (1+ quote-starting-pos)
+                           'syntax-table (string-to-syntax "|"))
+      (put-text-property (1- quote-ending-pos) quote-ending-pos
+                           'syntax-table (string-to-syntax "|")))))
+
+(defconst alpaca--syntax-propertize
+  (syntax-propertize-rules
+   ;;; Syntax rule for -- comments
+   ((rx (and (0+ " ") (group "--")
+             (0+ any) (group "\n")))
+    (1 "< b")
+    (2 "> b"))
+
+   ;;; Syntax rule for char literals
+   ((rx (and (1+ " ")
+             (group "'")
+             (optional "\\") any
+             (group "'")))
+    (1 "\"")
+    (2 "\""))
+
+   ((rx (and (or point
+                 (not (any ?\\ ?\"))
+                 (and (or (not (any ?\\)) point) ?\\ (* ?\\ ?\\) (any ?\")))
+             (* ?\\ ?\\)
+             "\"\"\""))
+    (0 (ignore (alpaca--syntax-stringify))))))
+
+(defun alpaca--syntax-propertize-function (begin end)
+  "Mark special lexemes between BEGIN and END."
+  (funcall alpaca--syntax-propertize begin end)
+  (save-excursion
+    (goto-char begin)
+    (while (re-search-forward "\\\\[({]" end t)
+      (let ((open (match-beginning 0)))
+        (add-text-properties open (1+ open) '(syntax-table (1 . nil)))))))
+
+(defvar alpaca--syntax-table
+  (let ((st (make-syntax-table)))
+    ;;; Syntax entry for {- -} type comments.
+    (modify-syntax-entry ?{ "(} 1n" st)
+    (modify-syntax-entry ?- ". 23n" st)
+    (modify-syntax-entry ?} "){ 4n" st)
+    (modify-syntax-entry ?\" "\"\"" st)
+    (modify-syntax-entry ?\\ "\\" st)
+    st))
+
+;;; Name regexp is according to https://github.com/alpaca-lang/alpaca-compiler/blob/353930a474fee4d833f962100edde70417691bca/src/Parse/Helpers.hs#L65
+(defconst alpaca--regexp-function
+  "^\\([a-z_][0-9A-Za-z_']*\\|([^)]+)\\)"
+  "A regular expression representing function names.")
+
+(defconst alpaca--font-lock-functions
+  (cons alpaca--regexp-function font-lock-function-name-face)
+  "Highlighting for function names.")
+
+(defconst alpaca--font-lock-data
+    `(,(rx symbol-start
+          (group (char upper) (1+ (or word ?_)))
+          symbol-end)
+     (1 font-lock-type-face))
+    "Highlighting data constructors.")
+
+(defconst alpaca--font-lock-number
+    `(,(rx (or digit symbol-start)
+          (group (or ?- ?+ ?%))
+          (or digit symbol-end))
+     (1 font-lock-variable-name-face))
+    "Highlighting numbers.")
+
+(defconst alpaca--font-lock-operator
+    `(,(rx (not word) (group (or "->" "==" ?= "!=" ">=" "=<" ?> ?< ?=)))
+     (1 font-lock-variable-name-face))
+    "Highlighting operators.")
+
+(defconst alpaca--font-lock-module
+  `(,(rx symbol-start
+            (group "module") (1+ space)
+            (group (1+ (or word ?_))))
+        (1 font-lock-keyword-face) (2 font-lock-type-face))
+  "Highlighting for module names.")
+
+(defconst alpaca--font-lock-export
+  `(,(rx line-start
+          (group "export") (1+ space)
+          (group (: (1+ (or word ?_)) ?/ (1+ digit))
+                 (* ?, (opt ?\n) (* space)
+                    (: (1+ (or word ?_)) ?/ (1+ digit))))
+          line-end)
+    (1 font-lock-keyword-face) (2 font-lock-variable-name-face))
+  "Highlighting for export.")
+
+(defconst alpaca--font-lock-export-type
+  `(,(rx line-start
+         (group "export_type") (1+ space)
+         (group (1+ (or word ?_))
+                (* ?, (opt ?\n) (* space)
+                   (1+ (or word ?_))))
+         line-end)
+    (1 font-lock-keyword-face)
+    (2 font-lock-variable-name-face))
+  "Highlighting for export_type.")
+
+(defconst alpaca--font-lock-type
+  `(,(rx line-start
+         (group "type") (1+ space) (group (1+ (or word ?_))) (1+ space)
+         (optional (group (1+ ?' (1+ (or word ?_)) (1+ space)))) ?=)
+    (1 font-lock-keyword-face)
+    (2 font-lock-function-name-face))
+  "Highlighting for types.")
+
+(defconst alpaca--font-lock-builtin
+  `(,(rx symbol-start
+         (group "is_" (or "integer" "float" "atom" "bool"
+                          "list" "string" "chars" "pid" "binary"))
+         symbol-end)
+    (1 font-lock-builtin-face))
+  "Highlihgint for buitin functions.")
+
+(defconst alpaca--regexp-operators
+  (concat "\\(" "`[^`]+`"
+          "\\|" "\\B\\\\"
+          "\\|" "[-+*/\\\\|<>=:!@#$%^&,.]+"
+          "\\)")
+  "A regular expression representing operators inside expressions.")
+
+(defconst alpaca--font-lock-operators
+  (cons alpaca--regexp-operators '(1 alpaca-font-lock-operators-face))
+  "Highlighting for operators inside expressions.")
+
+(defconst alpaca--regexp-multiline-list-comma-closing-brackets
+  (concat "^[[:space:]]*" (regexp-opt '("," "]" "}") t))
+  "A regular expression representing commas and closing brackets in multiline lists and records.")
+
+(defconst alpaca--font-lock-multiline-list-comma-closing-brackets
+  (cons alpaca--regexp-multiline-list-comma-closing-brackets
+        '(1 alpaca-font-lock-multiline-list-delimiters-face))
+  "Highlighting for commas and closing brackets in multiline lists and records.")
+
+(defun alpaca--match-multiline-list-opening-bracket (limit)
+  "Highlighting search function for opening brackets in multiline lists and records.
+Also highlights opening brackets without a matching bracket."
+  (when (alpaca--search-forward-opening-bracket limit)
+    (let ((opening (point))
+          (eol (line-end-position))
+          (closing (alpaca--search-forward-closing-bracket)))
+      (if (or (= closing opening) (> closing eol))
+          (progn
+            (set-match-data (match-data))
+            (goto-char (+ 1 opening))
+            t)
+        (alpaca--match-multiline-list-opening-bracket limit)))))
+
+(defun alpaca--search-forward-opening-bracket (limit)
+  "Go to the next opening bracket up to LIMIT."
+  (if (search-forward-regexp (regexp-opt '("[" "{")) limit t)
+      (progn
+        (backward-char)
+        t)))
+
+(defun alpaca--search-forward-closing-bracket ()
+  "Go to the next matching bracket, assuming that the cursor is on an opening bracket."
+  (ignore-errors
+    (save-match-data
+      (forward-sexp)))
+  (point))
+
+(defconst alpaca--font-lock-multiline-list-opening-brackets
+  '(alpaca--match-multiline-list-opening-bracket (0 alpaca-font-lock-multiline-list-delimiters-face))
+  "Highlighting for opening brackets in multiline lists and records.")
+
+(defconst alpaca--font-lock-highlighting
+  (list (list alpaca--font-lock-keywords
+              alpaca--font-lock-functions
+              alpaca--font-lock-module
+              alpaca--font-lock-data
+              alpaca--font-lock-number
+              alpaca--font-lock-operator
+              alpaca--font-lock-type
+              alpaca--font-lock-export
+              alpaca--font-lock-export-type
+              alpaca--font-lock-builtin
+              alpaca--font-lock-multiline-list-comma-closing-brackets
+              alpaca--font-lock-multiline-list-opening-brackets
+              alpaca--font-lock-operators)
+        nil nil))
+
+(defun turn-on-alpaca-font-lock ()
+  "Turn on Alpaca font lock."
+  (setq font-lock-multiline t)
+  (set-syntax-table alpaca--syntax-table)
+  (set (make-local-variable 'syntax-propertize-function) #'alpaca--syntax-propertize-function)
+  (set (make-local-variable 'font-lock-defaults) alpaca--font-lock-highlighting))
+
+(provide 'alpaca-font-lock)
+;;; alpaca-font-lock.el ends here

--- a/alpaca-indent.el
+++ b/alpaca-indent.el
@@ -1,0 +1,1297 @@
+;;; alpaca-indent.el --- "semi-intelligent" indentation module for Elm Mode
+
+;; Copyright 2004, 2005, 2007, 2008, 2009  Free Software Foundation, Inc.
+;; Copyright 1997-1998  Guy Lapalme
+;; Copyright 2015  Bogdan Popa
+;; Copyright (C) 2017 The Alpaca Community
+
+;; Author: 1997-1998 Guy Lapalme <lapalme@iro.umontreal.ca>
+
+;; Authors: Alpaca Community
+;; URL: https://github.com/alpaca-lang/alpaca-mode
+
+;; Keywords: indentation Alpaca layout-rule
+;; Version: 1.2
+;; URL: http://www.iro.umontreal.ca/~lapalme/layout/index.html
+
+;; This file is not part of GNU Emacs.
+
+;; This file was adapted from `elm-indent.el' which was adepted from `haskell-indent.el'.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Code:
+(require 's)
+
+(with-no-warnings
+  (require 'cl))
+
+;;; Customizations
+(defgroup alpaca-indent nil
+  "Alpaca indentation."
+  :group 'alpaca
+  :link '(custom-manual "(alpaca-mode)Indentation")
+  :prefix "alpaca-indent-")
+
+(defcustom alpaca-indent-offset 4
+  "Indentation of Alpaca statements with respect to containing block."
+  :type 'integer
+  :group 'alpaca-indent)
+
+(defcustom alpaca-indent-rhs-align-column 0
+  "Column on which to align right-hand sides (use 0 for ad-hoc alignment)."
+  :type 'integer
+  :group 'alpaca-indent)
+
+(defcustom alpaca-indent-look-past-empty-line t
+  "If nil, indentation engine will not look past an empty line for layout points."
+  :group 'alpaca-indent
+  :type 'boolean)
+
+(defcustom alpaca-indent-thenelse 0
+  "If non-zero, \"then\" and \"else\" are indented by that amount."
+  :group 'alpaca-indent
+  :type 'integer)
+
+(defcustom alpaca-indent-after-keywords
+  `(("of" ,alpaca-indent-offset)
+    ("in" ,alpaca-indent-offset 0)
+    ("{" ,alpaca-indent-offset)
+    "if"
+    "then"
+    "else"
+    "let")
+  "Keywords after which indentation should be indented by some offset.
+Each keyword info can have the following forms:
+
+   KEYWORD | (KEYWORD OFFSET [OFFSET-HANGING])
+
+If absent OFFSET-HANGING defaults to OFFSET.
+If absent OFFSET defaults to `alpaca-indent-offset'.
+
+OFFSET-HANGING is the offset to use in the case where the keyword
+is at the end of an otherwise-non-empty line."
+  :set-after '(alpaca-indent-offset)
+  :group 'alpaca-indent
+  :type '(repeat (choice string
+                         (cons :tag "" (string :tag "keyword:")
+                               (cons :tag "" (integer :tag "offset")
+                                     (choice (const nil)
+                                             (list :tag ""
+                                                   (integer :tag "offset-pending"))))))))
+
+(defcustom alpaca-indent-dont-hang '("(")
+  "Lexemes that should never be considered as hanging."
+  :group 'alpaca-indent
+  :type '(repeat string))
+
+
+;;; Internals
+(defconst alpaca-indent-start-keywords-re
+  (concat "\\<"
+          (regexp-opt '("module" "import" "type") t)
+          "\\>")
+  "Regexp for keywords to complete when standing at the first word of a line.")
+
+(defvar alpaca-indent-off-side-keywords-re
+  (concat "\\<"
+          (regexp-opt '("let"))
+          "\\>[ \t]*"))
+
+(defvar alpaca-indent-last-info nil)
+(defvar alpaca-indent-info)
+
+(defvar alpaca-indent-current-line-first-ident ""
+  "Global variable that keeps track of the first ident of the line to indent.")
+
+(defvar alpaca-indent-inhibit-after-offset nil)
+
+(defun alpaca-indent-point-to-col (apoint)
+  "Return the column number of APOINT."
+  (save-excursion
+    (goto-char apoint)
+    (current-column)))
+
+(defun alpaca-indent-push-col (col &optional name)
+  "Push indentation information for the column COL.
+The info is followed by NAME (if present).
+Makes sure that the same indentation info is not pushed twice.
+Uses free var `alpaca-indent-info'."
+  (let ((tmp (cons col name)))
+    (if (member tmp alpaca-indent-info)
+        alpaca-indent-info
+      (push tmp alpaca-indent-info))))
+
+(defun alpaca-indent-push-pos (pos &optional name)
+  "Push indentation information for POS followed by NAME (if present)."
+  (alpaca-indent-push-col (alpaca-indent-point-to-col pos) name))
+
+(defun alpaca-indent-column+offset (column offset)
+  (unless offset (setq offset alpaca-indent-offset))
+  (setq column (+ column offset)))
+
+(defun alpaca-indent-push-pos-offset (pos &optional offset)
+  "Pushes indentation information for the column corresponding to POS
+followed by an OFFSET (if present use its value otherwise use
+`alpaca-indent-offset')."
+  (alpaca-indent-push-col (alpaca-indent-column+offset
+                        (alpaca-indent-point-to-col pos)
+                        offset)))
+
+(defun alpaca-indent-empty-line-p ()
+  "Checks if the current line is empty; deals with Bird style scripts."
+  (save-excursion
+    (beginning-of-line)
+    (looking-at "[ \t]*$")))
+
+(defun alpaca-indent-skip-blanks-and-newlines-forward (end)
+  "Skip forward blanks, tabs and newlines until END."
+  (skip-chars-forward " \t\n" end))
+
+(defun alpaca-indent-skip-blanks-and-newlines-backward (start)
+  "Skip backward blanks, tabs and newlines up to START."
+  (skip-chars-backward " \t\n" start))
+
+(defun alpaca-indent-start-of-def ()
+  "Return the position of the start of a definition.
+The start of a def is expected to be recognizable by starting in column 0,
+unless `alpaca-indent-look-past-empty-line' is nil, in which case we
+take a coarser approximation and stop at the first empty line."
+  (save-excursion
+    (let ((start-code nil)
+          (top-col 0)
+          (save-point (point)))
+      ;; determine the starting point of the current piece of code
+      (setq start-code (if start-code (1+ start-code) (point-min)))
+      ;; go backward until the first preceding empty line
+      (forward-line -1)
+      (while (and (if alpaca-indent-look-past-empty-line
+                      (or (> (current-indentation) top-col)
+                          (alpaca-indent-empty-line-p))
+                    (and (> (current-indentation) top-col)
+                         (not (alpaca-indent-empty-line-p))))
+                  (> (point) start-code)
+                  (= 0 (forward-line -1))))
+      ;; go forward after the empty line
+      (if (alpaca-indent-empty-line-p)
+          (forward-line 1))
+      (setq start-code (point))
+      ;; find the first line of code which is not a comment
+      (forward-comment (point-max))
+      (if (> (point) save-point)
+          start-code
+        (point)))))
+
+(defun alpaca-indent-open-structure (start end)
+  "If any structure (list or tuple) is not closed, between START and END,
+returns the location of the opening symbol, nil otherwise."
+  (save-excursion
+    (nth 1 (parse-partial-sexp start end))))
+
+(defun alpaca-indent-in-string (start end)
+  "If a string is not closed , between START and END, returns the
+location of the opening symbol, nil otherwise."
+  (save-excursion
+    (let ((pps (parse-partial-sexp start end)))
+      (if (nth 3 pps) (nth 8 pps)))))
+
+(defun alpaca-indent-in-comment (start end)
+  "Check, starting from START, if END is at or within a comment.
+Returns the location of the start of the comment, nil otherwise."
+  (when (<= start end)
+    (let (pps)
+      (cond ((= start end) nil)
+            ((nth 4 (save-excursion (setq pps (parse-partial-sexp start end))))
+             (nth 8 pps))
+            ;; We also want to say that we are *at* the beginning of a comment.
+            ((and (not (nth 8 pps))
+                  (>= (point-max) (+ end 2))
+                  (nth 4 (save-excursion
+                           (setq pps (parse-partial-sexp end (+ end 2))))))
+             (nth 8 pps))))))
+
+(defun alpaca-indent-type-at-point ()
+  "Return the type of the line (also puts information in `match-data')."
+  (cond
+   ((alpaca-indent-empty-line-p) 'empty)
+   ((alpaca-indent-in-comment (point-min) (point)) 'comment)
+   ((looking-at "\\(\\([[:alpha:]]\\(\\sw\\|'\\)*\\)\\|_\\)[ \t\n]*") 'ident)
+   ((looking-at "\\(|[^|]\\)[ \t\n]*") 'guard)
+   ((looking-at "\\(=[^>=]\\|:[^:]\\|->\\|<-\\)[ \t\n]*") 'rhs)
+   (t 'other)))
+
+(defun alpaca-indent-contour-line (start end)
+  "Generate contour information between START and END points."
+  (if (< start end)
+      (save-excursion
+        (goto-char end)
+        (alpaca-indent-skip-blanks-and-newlines-backward start)
+        (let ((cur-col (current-column)) ; maximum column number
+              (fl 0) ; number of lines that forward-line could not advance
+              contour)
+          (while (and (> cur-col 0) (= fl 0) (>= (point) start))
+            (back-to-indentation)
+            (if (< (point) start) (goto-char start))
+            (and (not (member (alpaca-indent-type-at-point)
+                              '(empty comment))) ; skip empty and comment lines
+                 (< (current-column) cur-col) ; less indented column found
+                 (push (point) contour) ; new contour point found
+                 (setq cur-col (current-column)))
+            (setq fl (forward-line -1)))
+          contour))))
+
+(defun alpaca-indent-next-symbol (end)
+  "Move point to the next symbol."
+  (skip-syntax-forward ")" end)
+  (if (< (point) end)
+      (progn
+        (forward-sexp 1)
+        (alpaca-indent-skip-blanks-and-newlines-forward end))))
+
+(defun alpaca-indent-next-symbol-safe (end)
+  "Puts point to the next following symbol, or to end if there are no more symbols in the sexp."
+  (condition-case errlist (alpaca-indent-next-symbol end)
+    (error (goto-char end))))
+
+(defun alpaca-indent-separate-valdef (start end)
+  "Return a list of positions for important parts of a valdef."
+  (save-excursion
+    (let (valname valname-string aft-valname
+                  guard aft-guard
+                  rhs-sign aft-rhs-sign
+                  type)
+      ;; "parse" a valdef separating important parts
+      (goto-char start)
+      (setq type (alpaca-indent-type-at-point))
+      (if (or (memq type '(ident other))) ; possible start of a value def
+          (progn
+            (if (eq type 'ident)
+                (progn
+                  (setq valname (match-beginning 0))
+                  (setq valname-string (match-string 0))
+                  (goto-char (match-end 0)))
+              (skip-chars-forward " \t" end)
+              (setq valname (point))    ; type = other
+              (alpaca-indent-next-symbol-safe end))
+            (while (and (< (point) end)
+                        (setq type (alpaca-indent-type-at-point))
+                        (or (memq type '(ident other))))
+              (if (null aft-valname)
+                  (setq aft-valname (point)))
+              (alpaca-indent-next-symbol-safe end))))
+      (if (and (< (point) end) (eq type 'guard)) ; start of a guard
+          (progn
+            (setq guard (match-beginning 0))
+            (goto-char (match-end 0))
+            (while (and (< (point) end)
+                        (setq type (alpaca-indent-type-at-point))
+                        (not (eq type 'rhs)))
+              (if (null aft-guard)
+                  (setq aft-guard (point)))
+              (alpaca-indent-next-symbol-safe end))))
+      (if (and (< (point) end) (eq type 'rhs)) ; start of a rhs
+          (progn
+            (setq rhs-sign (match-beginning 0))
+            (goto-char (match-end 0))
+            (if (< (point) end)
+                (setq aft-rhs-sign (point)))))
+      (list valname valname-string aft-valname
+            guard aft-guard rhs-sign aft-rhs-sign))))
+
+(defsubst alpaca-indent-no-otherwise (guard)
+  "Check if there is no otherwise at GUARD."
+  (save-excursion
+    (goto-char guard)
+    (not (looking-at "|[ \t]*otherwise\\>"))))
+
+
+(defun alpaca-indent-guard (start end end-visible indent-info)
+  "Find indentation information for a line starting with a guard."
+  (save-excursion
+    (let* ((alpaca-indent-info indent-info)
+           (sep (alpaca-indent-separate-valdef start end))
+           (valname (nth 0 sep))
+           (guard (nth 3 sep))
+           (rhs-sign (nth 5 sep)))
+      ;; push information indentation for the visible part
+      (if (and guard (< guard end-visible) (alpaca-indent-no-otherwise guard))
+          (alpaca-indent-push-pos guard)
+        (if rhs-sign
+            (alpaca-indent-push-pos rhs-sign) ; probably within a data definition...
+          (if valname
+              (alpaca-indent-push-pos-offset valname))))
+      alpaca-indent-info)))
+
+(defun alpaca-indent-rhs (start end end-visible indent-info)
+  "Find indentation information for a line starting with a rhs."
+  (save-excursion
+    (let* ((alpaca-indent-info indent-info)
+           (sep (alpaca-indent-separate-valdef start end))
+           (valname (nth 0 sep))
+           (guard (nth 3 sep))
+           (rhs-sign (nth 5 sep)))
+      ;; push information indentation for the visible part
+      (if (and rhs-sign (< rhs-sign end-visible))
+          (alpaca-indent-push-pos rhs-sign)
+        (if (and guard (< guard end-visible))
+            (alpaca-indent-push-pos-offset guard)
+          (if valname                   ; always visible !!
+              (alpaca-indent-push-pos-offset valname))))
+      alpaca-indent-info)))
+
+(defconst alpaca-indent-decision-table
+  (let ((or "\\)\\|\\("))
+    (concat "\\("
+            "1.1.11" or                 ; 1= vn gd rh arh
+            "1.1.10" or                 ; 2= vn gd rh
+            "1.1100" or                 ; 3= vn gd agd
+            "1.1000" or                 ; 4= vn gd
+            "1.0011" or                 ; 5= vn rh arh
+            "1.0010" or                 ; 6= vn rh
+            "110000" or                 ; 7= vn avn
+            "100000" or                 ; 8= vn
+            "001.11" or                 ; 9= gd rh arh
+            "001.10" or                 ;10= gd rh
+            "001100" or                 ;11= gd agd
+            "001000" or                 ;12= gd
+            "000011" or                 ;13= rh arh
+            "000010" or                 ;14= rh
+            "000000"                    ;15=
+            "\\)")))
+
+(defun alpaca-indent-find-case (test)
+  "Find the index that matches TEST in the decision table."
+  (if (string-match alpaca-indent-decision-table test)
+      ;; use the fact that the resulting match-data is a list of the form
+      ;; (0 6 [2*(n-1) nil] 0 6) where n is the number of the matching regexp
+      ;; so n= ((length match-data)/2)-1
+      (- (/ (length (match-data 'integers)) 2) 1)
+    (error "alpaca-indent-find-case: impossible case: %s" test)))
+
+(defun alpaca-indent-after-list-item-p ()
+  (with-no-warnings
+    ;; HACK: we depend on open being dynamically bound while handling
+    ;; indentation inside of a parenthesized expression.
+    (when open
+      (or (eq (char-after open) ?\()
+          (eq (char-after open) ?\[)))))
+
+(defun alpaca-indent-empty (start end end-visible indent-info)
+  "Find indentation points for an empty line."
+  (save-excursion
+    (let* ((alpaca-indent-info indent-info)
+           (sep (alpaca-indent-separate-valdef start end))
+           (valname (pop sep))
+           (valname-string (pop sep))
+           (aft-valname (pop sep))
+           (guard (pop sep))
+           (aft-guard (pop sep))
+           (rhs-sign (pop sep))
+           (aft-rhs-sign (pop sep))
+           (last-line (= end end-visible))
+           (test (string
+                  (if valname ?1 ?0)
+                  (if (and aft-valname (< aft-valname end-visible)) ?1 ?0)
+                  (if (and guard (< guard end-visible)) ?1 ?0)
+                  (if (and aft-guard (< aft-guard end-visible)) ?1 ?0)
+                  (if (and rhs-sign (< rhs-sign end-visible)) ?1 ?0)
+                  (if (and aft-rhs-sign (< aft-rhs-sign end-visible)) ?1 ?0))))
+      (if (and valname-string           ; special case for start keywords
+               (string-match alpaca-indent-start-keywords-re valname-string))
+          (progn
+            (alpaca-indent-push-pos valname)
+            ;; Special case for `type' declarations.
+            (if (string-match "\\<type\\>" valname-string)
+                (alpaca-indent-push-pos-offset valname)
+              (alpaca-indent-push-pos-offset valname 0)))
+        (case                           ; general case
+            (alpaca-indent-find-case test)
+          ;; "1.1.11"   1= vn gd rh arh
+          (1 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos valname valname-string)
+             (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "| "))
+             (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "1.1.10"   2= vn gd rh
+          (2 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos valname valname-string)
+             (if last-line
+                 (alpaca-indent-push-pos-offset guard)
+               (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "| "))))
+          ;; "1.1100"   3= vn gd agd
+          (3 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos aft-guard)
+             (if last-line (alpaca-indent-push-pos-offset valname)))
+          ;; "1.1000"   4= vn gd
+          (4 (alpaca-indent-push-pos valname)
+             (if last-line (alpaca-indent-push-pos-offset guard 2)))
+          ;; "1.0011"   5= vn rh arh
+          (5 (alpaca-indent-push-pos valname)
+             (if (or (and aft-valname (= (char-after rhs-sign) ?\=))
+                     (= (char-after rhs-sign) ?\:))
+                 (alpaca-indent-push-pos valname valname-string))
+             (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "1.0010"   6= vn rh
+          (6 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos valname valname-string)
+             (if last-line (alpaca-indent-push-pos-offset valname)))
+          ;; "110000"   7= vn avn
+          (7 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos-offset valname))
+          ;; "100000"   8= vn
+          (8 (if (alpaca-indent-after-list-item-p)
+                 (progn
+                   (alpaca-indent-push-pos valname)
+                   (alpaca-indent-push-pos-offset valname))
+
+               (alpaca-indent-push-pos valname)
+               (alpaca-indent-push-pos-offset valname)))
+          ;; "001.11"   9= gd rh arh
+          (9 (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "| "))
+             (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "001.10"  10= gd rh
+          (10 (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "| "))
+              (if last-line (alpaca-indent-push-pos-offset guard)))
+          ;; "001100"  11= gd agd
+          (11 (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "|> "))
+              (alpaca-indent-push-pos aft-guard))
+          ;; "001000"  12= gd
+          (12 (if (alpaca-indent-no-otherwise guard) (alpaca-indent-push-pos guard "|> "))
+              (if last-line (alpaca-indent-push-pos-offset guard 2)))
+          ;; "000011"  13= rh arh
+          (13 (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "000010"  14= rh
+          (14 (if last-line (alpaca-indent-push-pos-offset rhs-sign 2 )))
+          ;; "000000"  15=
+          (t (error "alpaca-indent-empty: %s impossible case" test ))))
+      alpaca-indent-info)))
+
+(defun alpaca-indent-ident (start end end-visible indent-info)
+  "Find indentation points for a line starting with an identifier."
+  (save-excursion
+    (let*
+        ((alpaca-indent-info indent-info)
+         (sep (alpaca-indent-separate-valdef start end))
+         (valname (pop sep))
+         (valname-string (pop sep))
+         (aft-valname (pop sep))
+         (guard (pop sep))
+         (aft-guard (pop sep))
+         (rhs-sign (pop sep))
+         (aft-rhs-sign (pop sep))
+         (last-line (= end end-visible))
+         (is-where
+          (string-match "where[ \t]*" alpaca-indent-current-line-first-ident))
+         (diff-first                 ; not a function def with the same name
+          (or (null valname-string)
+              (not (string= (s-trim valname-string)
+                            (s-trim alpaca-indent-current-line-first-ident)))))
+
+         ;; (is-type-def
+         ;;  (and rhs-sign (eq (char-after rhs-sign) ?\:)))
+         (test (string
+                (if valname ?1 ?0)
+                (if (and aft-valname (< aft-valname end-visible)) ?1 ?0)
+                (if (and guard (< guard end-visible)) ?1 ?0)
+                (if (and aft-guard (< aft-guard end-visible)) ?1 ?0)
+                (if (and rhs-sign (< rhs-sign end-visible)) ?1 ?0)
+                (if (and aft-rhs-sign (< aft-rhs-sign end-visible)) ?1 ?0))))
+      (if (and valname-string           ; special case for start keywords
+               (string-match alpaca-indent-start-keywords-re valname-string))
+          (progn
+            (alpaca-indent-push-pos valname)
+            (if (string-match "\\<type\\>" valname-string)
+                ;; Special case for `type' declarations.
+                (alpaca-indent-push-pos-offset valname)
+              (if (not (string-match
+                        alpaca-indent-start-keywords-re
+                        alpaca-indent-current-line-first-ident))
+                  (alpaca-indent-push-pos-offset valname))))
+        (if (string= alpaca-indent-current-line-first-ident ":")
+            (if valname (alpaca-indent-push-pos valname))
+          (case                         ; general case
+              (alpaca-indent-find-case test)
+            ;; "1.1.11"   1= vn gd rh arh
+            (1 (if is-where
+                   (alpaca-indent-push-pos guard)
+                 (alpaca-indent-push-pos valname)
+                 (if diff-first (alpaca-indent-push-pos aft-rhs-sign))))
+            ;; "1.1.10"   2= vn gd rh
+            (2 (if is-where
+                   (alpaca-indent-push-pos guard)
+                 (alpaca-indent-push-pos valname)
+                 (if last-line
+                     (alpaca-indent-push-pos-offset guard))))
+            ;; "1.1100"   3= vn gd agd
+            (3 (if is-where
+                   (alpaca-indent-push-pos-offset guard)
+                 (alpaca-indent-push-pos valname)
+                 (if diff-first
+                     (alpaca-indent-push-pos aft-guard))))
+            ;; "1.1000"   4= vn gd
+            (4 (if is-where
+                   (alpaca-indent-push-pos guard)
+                 (alpaca-indent-push-pos valname)
+                 (if last-line
+                     (alpaca-indent-push-pos-offset guard 2))))
+            ;; "1.0011"   5= vn rh arh
+            (5 (if is-where
+                   (alpaca-indent-push-pos-offset valname)
+                 (alpaca-indent-push-pos valname)
+                 (if diff-first
+                     (alpaca-indent-push-pos aft-rhs-sign))))
+            ;; "1.0010"   6= vn rh
+            (6 (alpaca-indent-push-pos valname)
+               (alpaca-indent-push-pos valname valname-string)
+               (if last-line (alpaca-indent-push-pos-offset valname)))
+            ;; "110000"   7= vn avn
+            (7 (alpaca-indent-push-pos valname)
+               (alpaca-indent-push-pos-offset valname))
+            ;; "100000"   8= vn
+            (8 (alpaca-indent-push-pos valname)
+               (alpaca-indent-push-pos-offset valname))
+            ;; "001.11"   9= gd rh arh
+            (9 (if is-where
+                   (alpaca-indent-push-pos guard)
+                 (alpaca-indent-push-pos aft-rhs-sign)))
+            ;; "001.10"  10= gd rh
+            (10 (if is-where
+                    (alpaca-indent-push-pos guard)
+                  (if last-line
+                      (alpaca-indent-push-pos-offset guard))))
+            ;; "001100"  11= gd agd
+            (11 (if is-where
+                    (alpaca-indent-push-pos guard)
+                  (if (alpaca-indent-no-otherwise guard)
+                      (alpaca-indent-push-pos aft-guard))))
+            ;; "001000"  12= gd
+            (12 (if last-line (alpaca-indent-push-pos-offset guard 2)))
+            ;; "000011"  13= rh arh
+            (13 (alpaca-indent-push-pos aft-rhs-sign))
+            ;; "000010"  14= rh
+            (14 (if last-line (alpaca-indent-push-pos-offset rhs-sign 2)))
+            ;; "000000"  15=
+            (t (error "alpaca-indent-ident: %s impossible case" test )))))
+      alpaca-indent-info)))
+
+(defun alpaca-indent-other (start end end-visible indent-info)
+  "Find indentation points for a non-empty line starting with something other
+than an identifier, a guard or rhs."
+  (save-excursion
+    (let* ((alpaca-indent-info indent-info)
+           (sep (alpaca-indent-separate-valdef start end))
+           (valname (pop sep))
+           (valname-string (pop sep))
+           (aft-valname (pop sep))
+           (guard (pop sep))
+           (aft-guard (pop sep))
+           (rhs-sign (pop sep))
+           (aft-rhs-sign (pop sep))
+           (last-line (= end end-visible))
+           (test (string
+                  (if valname ?1 ?0)
+                  (if (and aft-valname (< aft-valname end-visible)) ?1 ?0)
+                  (if (and guard (< guard end-visible)) ?1 ?0)
+                  (if (and aft-guard (< aft-guard end-visible)) ?1 ?0)
+                  (if (and rhs-sign (< rhs-sign end-visible)) ?1 ?0)
+                  (if (and aft-rhs-sign (< aft-rhs-sign end-visible)) ?1 ?0))))
+      (if (and valname-string           ; special case for start keywords
+               (string-match alpaca-indent-start-keywords-re valname-string))
+          (alpaca-indent-push-pos-offset valname)
+        (case                           ; general case
+            (alpaca-indent-find-case test)
+          ;; "1.1.11"   1= vn gd rh arh
+          (1 (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "1.1.10"   2= vn gd rh
+          (2 (if last-line
+                 (alpaca-indent-push-pos-offset guard)
+               (alpaca-indent-push-pos-offset rhs-sign 2)))
+          ;; "1.1100"   3= vn gd agd
+          (3 (alpaca-indent-push-pos aft-guard))
+          ;; "1.1000"   4= vn gd
+          (4 (alpaca-indent-push-pos-offset guard 2))
+          ;; "1.0011"   5= vn rh arh
+          (5 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "1.0010"   6= vn rh
+          (6 (if last-line
+                 (alpaca-indent-push-pos-offset valname)
+               (alpaca-indent-push-pos-offset rhs-sign 2)))
+          ;; "110000"   7= vn avn
+          (7 (alpaca-indent-push-pos valname)
+             (alpaca-indent-push-pos-offset valname))
+          ;; "100000"   8= vn
+          (8 (alpaca-indent-push-pos valname))
+          ;; "001.11"   9= gd rh arh
+          (9 (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "001.10"  10= gd rh
+          (10 (if last-line
+                  (alpaca-indent-push-pos-offset guard)
+                (alpaca-indent-push-pos-offset rhs-sign 2)))
+          ;; "001100"  11= gd agd
+          (11 (if (alpaca-indent-no-otherwise guard)
+                  (alpaca-indent-push-pos aft-guard)))
+          ;; "001000"  12= gd
+          (12 (if last-line (alpaca-indent-push-pos-offset guard 2)))
+          ;; "000011"  13= rh arh
+          (13 (alpaca-indent-push-pos aft-rhs-sign))
+          ;; "000010"  14= rh
+          (14 (if last-line (alpaca-indent-push-pos-offset rhs-sign 2)))
+          ;; "000000"  15=
+          (t (error "alpaca-indent-other: %s impossible case" test ))))
+      alpaca-indent-info)))
+
+(defun alpaca-indent-valdef-indentation (start end end-visible curr-line-type
+                                            indent-info)
+  "Find indentation information for a value definition."
+  (let ((alpaca-indent-info indent-info))
+    (if (< start end-visible)
+        (case curr-line-type
+          (empty (alpaca-indent-empty start end end-visible indent-info))
+          (ident (alpaca-indent-ident start end end-visible indent-info))
+          (guard (alpaca-indent-guard start end end-visible indent-info))
+          (rhs   (alpaca-indent-rhs start end end-visible indent-info))
+          (comment (error "Comment indent should never happen"))
+          (other (alpaca-indent-other start end end-visible indent-info)))
+      alpaca-indent-info)))
+
+(defun alpaca-indent-line-indentation (line-start line-end end-visible
+                                               curr-line-type indent-info)
+  "Compute indentation info between LINE-START and END-VISIBLE.
+Separate a line of program into valdefs between offside keywords
+and find indentation info for each part."
+  (save-excursion
+    ;; point is (already) at line-start
+    (assert (eq (point) line-start))
+    (let ((alpaca-indent-info indent-info)
+          (start (or (alpaca-indent-in-comment line-start line-end)
+                     (alpaca-indent-in-string line-start line-end))))
+      (if start                         ; if comment at the end
+          (setq line-end start))  ; end line before it
+      ;; loop on all parts separated by off-side-keywords
+      (while (and (re-search-forward alpaca-indent-off-side-keywords-re
+                                     line-end t)
+                  (not (or (alpaca-indent-in-comment line-start (point))
+                           (alpaca-indent-in-string line-start (point)))))
+        (let ((beg-match (match-beginning 0)) ; save beginning of match
+              (end-match (match-end 0)))      ; save end of match
+          ;; Do not try to find indentation points if off-side-keyword at
+          ;; the start...
+          (if (or (< line-start beg-match)
+                  ;; Actually, if we're looking at a "let" inside a "do", we
+                  ;; should add the corresponding indentation point.
+                  (eq (char-after beg-match) ?l))
+              (setq alpaca-indent-info
+                    (alpaca-indent-valdef-indentation line-start beg-match
+                                                   end-visible
+                                                   curr-line-type
+                                                   alpaca-indent-info)))
+          ;; ...but keep the start of the line if keyword alone on the line
+          (if (= line-end end-match)
+              (alpaca-indent-push-pos beg-match))
+          (setq line-start end-match)
+          (goto-char line-start)))
+      (alpaca-indent-valdef-indentation line-start line-end end-visible
+                                     curr-line-type alpaca-indent-info))))
+
+
+(defun alpaca-indent-layout-indent-info (start contour-line)
+  (let ((alpaca-indent-info nil)
+        (curr-line-type (alpaca-indent-type-at-point))
+        line-start line-end end-visible)
+    (save-excursion
+      (if (eq curr-line-type 'ident)
+          (let                          ; guess the type of line
+              ((sep
+                (alpaca-indent-separate-valdef
+                 (point) (line-end-position))))
+            ;; if the first ident is where or the start of a def
+            ;; keep it in a global variable
+            (setq alpaca-indent-current-line-first-ident
+                  (if (string-match "where[ \t]*" (nth 1 sep))
+                      (nth 1 sep)
+                    (if (nth 5 sep)              ; is there a rhs-sign
+                        (if (= (char-after (nth 5 sep)) ?\:) ;is it a typdef
+                            ":" (nth 1 sep))
+                      "")))))
+      (while contour-line               ; explore the contour points
+        (setq line-start (pop contour-line))
+        (goto-char line-start)
+        (setq line-end (line-end-position))
+        (setq end-visible            ; visible until the column of the
+              (if contour-line       ; next contour point
+                  (save-excursion
+                    (move-to-column
+                     (alpaca-indent-point-to-col (car contour-line)))
+                    (point))
+                line-end))
+        (unless (or (alpaca-indent-open-structure start line-start)
+                    (alpaca-indent-in-comment start line-start))
+          (setq alpaca-indent-info
+                (alpaca-indent-line-indentation line-start line-end
+                                             end-visible curr-line-type
+                                             alpaca-indent-info)))))
+    alpaca-indent-info))
+
+(defun alpaca-indent-find-matching-start (regexp limit &optional pred start)
+  (let ((open (alpaca-indent-open-structure limit (point))))
+    (if open (setq limit (1+ open))))
+  (unless start (setq start (point)))
+  (when (re-search-backward regexp limit t)
+    (let ((nestedcase (match-end 1))
+          (outer (or (alpaca-indent-in-string limit (point))
+                     (alpaca-indent-in-comment limit (point))
+                     (alpaca-indent-open-structure limit (point))
+                     (if (and pred (funcall pred start)) (point)))))
+      (cond
+       (outer
+        (goto-char outer)
+        (alpaca-indent-find-matching-start regexp limit pred start))
+       (nestedcase
+        ;; Nested case.
+        (and (alpaca-indent-find-matching-start regexp limit pred)
+             (alpaca-indent-find-matching-start regexp limit pred start)))
+       (t (point))))))
+
+
+(defun alpaca-indent-comment (open start)
+  "Compute indent info for comments and text inside comments.
+OPEN is the start position of the comment in which point is."
+  ;; Ideally we'd want to guess whether it's commented out code or
+  ;; whether it's text.  Instead, we'll assume it's text.
+  (save-excursion
+    (if (= open (point))
+        ;; We're actually just in front of a comment: align with following
+        ;; code or with comment on previous line.
+        (let ((prev-line-info
+               (cond
+                ((eq (char-after) ?\{) nil) ;Align as if it were code.
+                ((and (forward-comment -1)
+                      (> (line-beginning-position 3) open))
+                 ;; We're after another comment and there's no empty line
+                 ;; between us.
+                 (list (list (alpaca-indent-point-to-col (point)))))
+                (t nil))))              ;Else align as if it were code
+          ;; Align with following code.
+          (forward-comment (point-max))
+          ;; There are several possible indentation points for this code-line,
+          ;; but the only valid indentation point for the comment is the one
+          ;; that the user will select for the code-line.  Obviously we can't
+          ;; know that, so we just assume that the code-line is already at its
+          ;; proper place.
+          ;; Strictly speaking "assume it's at its proper place" would mean
+          ;; we'd just use (current-column), but since this is using info from
+          ;; lines further down and it's common to reindent line-by-line,
+          ;; we'll align not with the current indentation, but with the
+          ;; one that auto-indentation "will" select.
+          (append
+           prev-line-info
+           (let ((indent-info (save-excursion
+                                (alpaca-indent-indentation-info start)))
+                 (col (current-column)))
+             ;; Sort the indent-info so that the current indentation comes
+             ;; out first.
+             (setq indent-info
+                   (sort indent-info
+                         (lambda (x y)
+                           (<= (abs (- col (car x))) (abs (- col (car y)))))))
+             indent-info)))
+
+      ;; We really are inside a comment.
+      (if (looking-at "-}")
+          (progn
+            (forward-char 2)
+            (forward-comment -1)
+            (list (list (1+ (alpaca-indent-point-to-col (point))))))
+        (let ((offset (if (looking-at "--?")
+                          (- (match-beginning 0) (match-end 0)))))
+          (forward-line -1)             ;Go to previous line.
+          (back-to-indentation)
+          (if (< (point) start) (goto-char start))
+
+          (list (list (if (and comment-start-skip (looking-at comment-start-skip))
+                          (if offset
+                              (+ 2 offset (alpaca-indent-point-to-col (point)))
+                            (alpaca-indent-point-to-col (match-end 0)))
+                        (alpaca-indent-point-to-col (point))))))))))
+
+(defun alpaca-indent-closing-keyword (start)
+  (let ((open (save-excursion
+                (alpaca-indent-find-matching-start
+                 (case (char-after)
+                   (?i "\\<\\(?:\\(in\\)\\|let\\)\\>")
+                   (?o "\\<\\(?:\\(of\\)\\|case\\)\\>")
+                   (?t "\\<\\(?:\\(then\\)\\|if\\)\\>")
+                   (?e "\\<\\(?:\\(else\\)\\|if\\)\\>"))
+                 start))))
+    ;; For a "hanging let/case/if at EOL" we should use a different
+    ;; indentation scheme.
+    (save-excursion
+      (goto-char open)
+      (if (alpaca-indent-hanging-p)
+          (setq open (alpaca-indent-virtual-indentation start))))
+    ;; FIXME: we should try and figure out if the `if' is in a `do' layout
+    ;; before using alpaca-indent-thenelse.
+    (list (list (+ (if (memq (char-after) '(?t ?e)) alpaca-indent-thenelse 0)
+                   (alpaca-indent-point-to-col open))))))
+
+(defun alpaca-indent-skip-lexeme-forward ()
+  (and (zerop (skip-syntax-forward "w"))
+       (skip-syntax-forward "_")
+       (skip-syntax-forward "(")
+       (skip-syntax-forward ")")))
+
+(defun alpaca-indent-offset-after-info ()
+  "Return the info from `alpaca-indent-after-keywords' for keyword at point."
+  (let ((id (buffer-substring
+             (point)
+             (save-excursion
+               (alpaca-indent-skip-lexeme-forward)
+               (point)))))
+    (or (assoc id alpaca-indent-after-keywords)
+        (car (member id alpaca-indent-after-keywords)))))
+
+(defun alpaca-indent-hanging-p ()
+  ;; A Hanging keyword is one that's at the end of a line except it's not at
+  ;; the beginning of a line.
+  (not (or (= (current-column) (current-indentation))
+           (save-excursion
+             (let ((lexeme
+                    (buffer-substring
+                     (point)
+                     (progn (alpaca-indent-skip-lexeme-forward) (point)))))
+               (or (member lexeme alpaca-indent-dont-hang)
+                   (> (line-end-position)
+                      (progn (forward-comment (point-max)) (point)))))))))
+
+(defun alpaca-indent-after-keyword-column (offset-info start &optional default)
+  (unless offset-info
+    (setq offset-info (alpaca-indent-offset-after-info)))
+  (unless default (setq default alpaca-indent-offset))
+  (setq offset-info
+        (if alpaca-indent-inhibit-after-offset '(0) (cdr-safe offset-info)))
+  (if (not (alpaca-indent-hanging-p))
+      (alpaca-indent-column+offset (current-column)
+                                (or (car offset-info) default))
+    ;; The keyword is hanging at the end of the line.
+    (alpaca-indent-column+offset
+     (alpaca-indent-virtual-indentation start)
+     (or (cadr offset-info) (car offset-info) default))))
+
+(defun alpaca-indent-inside-paren-update-syntax-p (open)
+  (let ((end (point)))
+    (save-excursion
+      (goto-char open)
+      (and (not (looking-at ".*="))
+           (progn
+             (forward-line)
+             (alpaca-indent-skip-blanks-and-newlines-forward end)
+             (eq (char-after) ?\|))))))
+
+(defun alpaca-indent-inside-paren (open)
+  ;; there is an open structure to complete
+  (if (looking-at "\\s)\\|[|;,]")
+      ;; A close-paren or a , or ; can only correspond syntactically to
+      ;; the open-paren at `open'.  So there is no ambiguity.
+      (let* ((is-close-brace (eq (char-after) ?\}))
+             (inside-update (alpaca-indent-inside-paren-update-syntax-p open)))
+        (if (and (eq (char-after) ?\;) (eq (char-after open) ?\())
+            (message "Mismatched punctuation: `%c' in %c...%c"
+                     (char-after) (char-after open)
+                     (if (eq (char-after open) ?\() ?\) ?\})))
+        (save-excursion
+          (goto-char open)
+          (list (list
+                 (if (alpaca-indent-hanging-p)
+                     (alpaca-indent-virtual-indentation nil)
+                   (if (and inside-update
+                            (not is-close-brace)
+                            (eq (char-after open) ?\{))
+                       (alpaca-indent-point-to-col (+ alpaca-indent-offset open))
+                     (alpaca-indent-point-to-col open)))))))
+    ;; There might still be layout within the open structure.
+    (let* ((end (point))
+           (basic-indent-info
+            ;; Anything else than a ) is subject to layout.
+            (if (looking-at "\\s.\\|\\$ ")
+                (alpaca-indent-point-to-col open) ; align a punct with (
+              (let ((follow (save-excursion
+                              (goto-char (1+ open))
+                              (alpaca-indent-skip-blanks-and-newlines-forward end)
+                              (point))))
+                (if (= follow end)
+                    (save-excursion
+                      (goto-char open)
+                      (alpaca-indent-after-keyword-column nil nil 1))
+                  (alpaca-indent-point-to-col (+ alpaca-indent-offset follow))))))
+           (open-column (alpaca-indent-point-to-col open))
+           (contour-line (alpaca-indent-contour-line (1+ open) end)))
+      (if (null contour-line)
+          (list (list basic-indent-info))
+        (let ((indent-info
+               (alpaca-indent-layout-indent-info
+                (1+ open) contour-line)))
+          ;; Fix up indent info.
+          (let ((base-elem (assoc open-column indent-info)))
+            (if base-elem
+                (progn (setcar base-elem basic-indent-info)
+                       (setcdr base-elem nil))
+              (if (not (eq basic-indent-info 0))
+                  (setq indent-info (append (list (list basic-indent-info)) indent-info))
+                (setq indent-info (append indent-info (list (list basic-indent-info))))))
+            indent-info))))))
+
+(defun alpaca-indent-virtual-indentation (start)
+  "Compute the \"virtual indentation\" of text at point.
+The \"virtual indentation\" is the indentation that text at point would have
+had, if it had been placed on its own line."
+  (let ((col (current-column))
+        (alpaca-indent-inhibit-after-offset (alpaca-indent-hanging-p)))
+    (if (save-excursion (skip-chars-backward " \t") (bolp))
+        ;; If the text is indeed on its own line, than the virtual indent is
+        ;; the current indentation.
+        col
+      ;; Else, compute the indentation that it would have had.
+      (let ((info (alpaca-indent-indentation-info start))
+            (max -1))
+        ;; `info' is a list of possible indent points.  Each indent point is
+        ;; assumed to correspond to a different parse.  So we need to find
+        ;; the parse that corresponds to the case at hand (where there's no
+        ;; line break), which is assumed to always be the
+        ;; deepest indentation.
+        (dolist (x info)
+          (setq x (car x))
+          ;; Sometimes `info' includes the current indentation (or yet
+          ;; deeper) by mistake, because alpaca-indent-indentation-info
+          ;; wasn't designed to be called on a piece of text that is not at
+          ;; BOL.  So ignore points past `col'.
+          (if (and (> x max) (not (>= x col)))
+              (setq max x)))
+        ;; In case all the indent points are past `col', just use `col'.
+        (if (>= max 0) max col)))))
+
+(defun alpaca-indent-indentation-info (&optional start)
+  "Return a list of possible indentations for the current line.
+These are then used by `alpaca-indent-cycle'.
+START if non-nil is a presumed start pos of the current definition."
+  (unless start (setq start (alpaca-indent-start-of-def)))
+  (let (open contour-line)
+    (cond
+     ;; in string?
+     ((setq open (alpaca-indent-in-string start (point)))
+      (list (list (+ (alpaca-indent-point-to-col open)
+                     (if (looking-at "\\\\") 0 1)))))
+
+     ;; in comment ?
+     ((setq open (alpaca-indent-in-comment start (point)))
+      (alpaca-indent-comment open start))
+
+     ;; Closing the declaration part of a `let' or the test exp part of a case.
+     ((looking-at "\\(?:in\\|of\\|then\\|else\\)\\>")
+      (alpaca-indent-closing-keyword start))
+
+     ;; Right after a special keyword.
+     ((save-excursion
+        (forward-comment (- (point-max)))
+        (when (and (not (zerop (skip-syntax-backward "w")))
+                   (setq open (alpaca-indent-offset-after-info)))
+          (list (list (alpaca-indent-after-keyword-column open start))))))
+
+     ;; open structure? ie  ( { [
+     ((setq open (alpaca-indent-open-structure start (point)))
+      (alpaca-indent-inside-paren open))
+
+     ;; full indentation
+     ((setq contour-line (alpaca-indent-contour-line start (point)))
+      (alpaca-indent-layout-indent-info start contour-line))
+
+     (t
+      ;; simple contour just one indentation at start
+      (list (list (alpaca-indent-point-to-col start)))))))
+
+(defun alpaca-indent-cycle ()
+  "Indentation cycle.
+
+We stay in the cycle as long as the TAB key is pressed."
+  (interactive "*")
+  (let ((marker (if (> (current-column)
+                       (current-indentation))
+                    (point-marker)))
+        (bol (progn (beginning-of-line) (point))))
+    (back-to-indentation)
+    (unless (and (eq last-command this-command)
+                 (eq bol (car alpaca-indent-last-info)))
+      (save-excursion
+        (setq alpaca-indent-last-info
+              (list bol (alpaca-indent-indentation-info) 0 0))))
+
+    (let* ((il (nth 1 alpaca-indent-last-info))
+           (index (nth 2 alpaca-indent-last-info))
+           (last-insert-length (nth 3 alpaca-indent-last-info))
+           (indent-info (nth index il)))
+
+      (indent-line-to (car indent-info)) ; insert indentation
+      (delete-char last-insert-length)
+      (setq last-insert-length 0)
+      (let ((text (cdr indent-info)))
+        (if text
+            (progn
+              (insert text)
+              (setq last-insert-length (length text)))))
+
+      (setq alpaca-indent-last-info
+            (list bol il (% (1+ index) (length il)) last-insert-length))
+
+      (if (= (length il) 1)
+          (message "Sole indentation")
+        (message "Indent cycle (%d)..." (length il)))
+
+      (if marker
+          (goto-char (marker-position marker))))))
+
+(defun alpaca-indent-region (start end)
+  "Apply `alpaca-indent-cycle' to every line between START and END."
+  (save-excursion
+    (goto-char start)
+    (while (< (point) end)
+      (alpaca-indent-cycle)
+      (forward-line))))
+
+;;; Alignment functions
+(defun alpaca-indent-shift-columns (dest-column region-stack)
+  "Shift columns in REGION-STACK to go to DEST-COLUMN.
+Elements of the stack are pairs of points giving the start and end
+of the regions to move."
+  (let (reg col diffcol reg-end)
+    (while (setq reg (pop region-stack))
+      (setq reg-end (copy-marker (cdr reg)))
+      (goto-char (car reg))
+      (setq col (current-column))
+      (setq diffcol (- dest-column col))
+      (if (not (zerop diffcol))
+          (catch 'end-of-buffer
+            (while (<= (point) (marker-position reg-end))
+              (if (< diffcol 0)
+                  (backward-delete-char-untabify (- diffcol) nil)
+                (insert-char ?\  diffcol))
+              (end-of-line 2)           ; should be (forward-line 1)
+              (if (eobp)                ; but it adds line at the end...
+                  (throw 'end-of-buffer nil))
+              (move-to-column col)))))))
+
+(defun alpaca-indent-align-def (p-arg type)
+  "Align guards or rhs within the current definition before point.
+If P-ARG is t align all defs up to the mark.
+TYPE is either 'guard or 'rhs."
+  (save-excursion
+    (let (start-block end-block
+                      (maxcol (if (eq type 'rhs) alpaca-indent-rhs-align-column 0))
+                      contour sep defname defnamepos
+                      defcol pos lastpos
+                      regstack eqns-start start-found)
+      ;; find the starting and ending boundary points for alignment
+      (if p-arg
+          (if (mark)                    ; aligning everything in the region
+              (progn
+                (when (> (mark) (point)) (exchange-point-and-mark))
+                (setq start-block
+                      (save-excursion
+                        (goto-char (mark))
+                        (line-beginning-position)))
+                (setq end-block
+                      (progn (if (bolp)
+                                 (forward-line -1))
+                             (line-end-position))))
+            (error "The mark is not set for aligning definitions"))
+        ;; aligning the current definition
+        (setq start-block (alpaca-indent-start-of-def))
+        (setq end-block (line-end-position)))
+      ;; find the start of the current valdef using the contour line
+      ;; in reverse order because we need the nearest one from the end
+      (setq contour
+            (reverse (alpaca-indent-contour-line start-block end-block)))
+      (setq pos (car contour))          ; keep the start of the first contour
+      ;; find the nearest start of a definition
+      (while (and (not defname) contour)
+        (goto-char (pop contour))
+        (if (alpaca-indent-open-structure start-block (point))
+            nil
+          (setq sep (alpaca-indent-separate-valdef (point) end-block))
+          (if (nth 5 sep)               ; is there a rhs?
+              (progn (setq defnamepos (nth 0 sep))
+                     (setq defname (nth 1 sep))))))
+      ;; start building the region stack
+      (if defnamepos
+          (progn                        ; there is a valdef
+            ;; find the start of each equation or guard
+            (if p-arg      ; when indenting a region
+                ;; accept any start of id or pattern as def name
+                (setq defname "\\<\\|("))
+            (setq defcol (alpaca-indent-point-to-col defnamepos))
+            (goto-char pos)
+            (setq end-block (line-end-position))
+            (catch 'top-of-buffer
+              (while (and (not start-found)
+                          (>= (point) start-block))
+                (if (<= (current-indentation) defcol)
+                    (progn
+                      (move-to-column defcol)
+                      (if (and (looking-at defname) ; start of equation
+                               (not (alpaca-indent-open-structure start-block (point))))
+                          (push (cons (point) 'eqn) eqns-start)
+                        ;; found a less indented point not starting an equation
+                        (setq start-found t)))
+                  ;; more indented line
+                  (back-to-indentation)
+                  (if (and (eq (alpaca-indent-type-at-point) 'guard) ; start of a guard
+                           (not (alpaca-indent-open-structure start-block (point))))
+                      (push (cons (point) 'gd) eqns-start)))
+                (if (bobp)
+                    (throw 'top-of-buffer nil)
+                  (backward-to-indentation 1))))
+            ;; remove the spurious guards before the first equation
+            (while (and eqns-start (eq (cdar eqns-start) 'gd))
+              (pop eqns-start))
+            ;; go through each equation to find the region to indent
+            (while eqns-start
+              (let ((eqn (caar eqns-start)))
+                (setq lastpos (if (cdr eqns-start)
+                                  (save-excursion
+                                    (goto-char (caadr eqns-start))
+                                    (forward-line -1)
+                                    (line-end-position))
+                                end-block))
+                (setq sep (alpaca-indent-separate-valdef eqn lastpos)))
+              (if (eq type 'guard)
+                  (setq pos (nth 3 sep))
+                ;; check if what follows a rhs sign is more indented or not
+                (let ((rhs (nth 5 sep))
+                      (aft-rhs (nth 6 sep)))
+                  (if (and rhs aft-rhs
+                           (> (alpaca-indent-point-to-col rhs)
+                              (alpaca-indent-point-to-col aft-rhs)))
+                      (setq pos aft-rhs)
+                    (setq pos rhs))))
+              (if pos
+                  (progn                ; update region stack
+                    (push (cons pos (or lastpos pos)) regstack)
+                    (setq maxcol        ; find the highest column number
+                          (max maxcol
+                               (progn   ;find the previous non-empty column
+                                 (goto-char pos)
+                                 (skip-chars-backward
+                                  " \t"
+                                  (line-beginning-position))
+                                 (if (bolp)
+                                     ;;if on an empty prefix
+                                     (alpaca-indent-point-to-col pos) ;keep original indent
+                                   (1+ (alpaca-indent-point-to-col (point)))))))))
+              (pop eqns-start))
+            ;; now shift according to the region stack
+            (if regstack
+                (alpaca-indent-shift-columns maxcol regstack)))))))
+
+
+;;; Insertion functions
+(defun alpaca-indent-insert-equal ()
+  "Insert an = sign and align the previous rhs of the current function."
+  (interactive "*")
+  (if (or (bolp)
+          (/= (preceding-char) ?\ ))
+      (insert ?\ ))
+  (insert "= ")
+  (alpaca-indent-align-def mark-active 'rhs))
+
+
+;;; alpaca-indent-mode
+(defvar alpaca-indent-mode nil
+  "Non-nil if the semi-intelligent Alpaca indentation mode is in effect.")
+(make-variable-buffer-local 'alpaca-indent-mode)
+
+(defvar alpaca-indent-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [?\C-c ?\C-=] 'alpaca-indent-insert-equal)
+    map))
+
+;;;###autoload
+(defun turn-on-alpaca-indent ()
+  "Turn on ``intelligent'' Alpaca indentation mode."
+  (set (make-local-variable 'indent-line-function) 'alpaca-indent-cycle)
+  (set (make-local-variable 'indent-region-function) 'alpaca-indent-region)
+  (setq alpaca-indent-mode t)
+  ;; Activate our keymap.
+  (let ((map (current-local-map)))
+    (while (and map (not (eq map alpaca-indent-map)))
+      (setq map (keymap-parent map)))
+    (if map
+        ;; alpaca-indent-map is already active: nothing to do.
+        nil
+      ;; Put our keymap on top of the others.  We could also put it in
+      ;; second place, or in a minor-mode.  The minor-mode approach would be
+      ;; easier, but it's harder for the user to override it.  This approach
+      ;; is the closest in behavior compared to the previous code that just
+      ;; used a bunch of local-set-key.
+      (set-keymap-parent alpaca-indent-map (current-local-map))
+      ;; Protect our keymap.
+      (setq map (make-sparse-keymap))
+      (set-keymap-parent map alpaca-indent-map)
+      (use-local-map map)))
+  (run-hooks 'alpaca-indent-hook))
+
+(defun turn-off-alpaca-indent ()
+  "Turn off ``intelligent'' Alpaca indentation mode."
+  (kill-local-variable 'indent-line-function)
+  ;; Remove alpaca-indent-map from the local map.
+  (let ((map (current-local-map)))
+    (while map
+      (let ((parent (keymap-parent map)))
+        (if (eq alpaca-indent-map parent)
+            (set-keymap-parent map (keymap-parent parent))
+          (setq map parent)))))
+  (setq alpaca-indent-mode nil))
+
+;; Put this minor mode on the global minor-mode-alist.
+(or (assq 'alpaca-indent-mode (default-value 'minor-mode-alist))
+    (setq-default minor-mode-alist
+                  (append (default-value 'minor-mode-alist)
+                          '((alpaca-indent-mode " Alpaca Indent")))))
+
+;;;###autoload
+(defun alpaca-indent-mode (&optional arg)
+  "``Intelligent'' Alpaca indentation mode.
+
+This deals with the layout rules of Alpaca.
+
+\\[alpaca-indent-cycle] starts the cycle which proposes new
+possibilities as long as the TAB key is pressed.  Any other key
+or mouse click terminates the cycle and is interpreted except for
+RET which merely exits the cycle.
+
+Other special keys are:
+
+    \\[alpaca-indent-insert-equal]
+      inserts an =
+
+Invokes `alpaca-indent-hook' if not nil."
+  (interactive "P")
+  (setq alpaca-indent-mode
+        (if (null arg)
+            (not alpaca-indent-mode)
+          (> (prefix-numeric-value arg) 0)))
+  (if alpaca-indent-mode
+      (turn-on-alpaca-indent)
+    (turn-off-alpaca-indent)))
+
+(provide 'alpaca-indent)
+;;; alpaca-indent.el ends here

--- a/alpaca-mode.el
+++ b/alpaca-mode.el
@@ -23,108 +23,27 @@
 
 ;;; Code:
 
-(defconst alpaca-font-lock-keywords
-  ;; Reserved words
-  `(,(rx symbol-start
-         (or "let" "in"
-             "match" "with"
-             "beam"
-             "spawn" "send" "receive" "after"
-             "test"
-             "error" "exit" "throw"
-             "true" "false"
-             "unit" "size" "end" "sign"
-             "big" "little" "native" "utf8")
-         symbol-end)
+(require 'alpaca-indent)
+(require 'alpaca-font-lock)
 
-    ;; Module definition
-    (,(rx symbol-start
-          (group "module") (1+ space)
-          (group (1+ (or word ?_))))
-     (1 font-lock-keyword-face) (2 font-lock-type-face))
-
-    ;; Export function
-    (,(rx line-start
-          (group "export") (1+ space)
-          (group (: (1+ (or word ?_)) ?/ (1+ digit))
-                 (* ?, (opt ?\n) (* space)
-                    (: (1+ (or word ?_)) ?/ (1+ digit))))
-          line-end)
-     (1 font-lock-keyword-face) (2 font-lock-variable-name-face))
-
-    ;; Export type
-    (,(rx line-start
-          (group "export_type") (1+ space)
-          (group (1+ (or word ?_))
-                 (* ?, (opt ?\n) (* space)
-                    (1+ (or word ?_))))
-          line-end)
-     (1 font-lock-keyword-face)
-     (2 font-lock-variable-name-face))
-
-    ;; FIXME: Multi-line comments
-    ;; (,(rx (group "{-") (group (* anything)) (group "-}"))
-    ;;  (1 font-lock-comment-delimiter-face)
-    ;;  (2 font-lock-comment-face)
-    ;;  (3 font-lock-comment-delimiter-face))
-
-    ;; Type definition
-    (,(rx line-start
-          (group "type") (1+ space) (group (1+ (or word ?_))) (1+ space)
-          (group (1+ ?' (1+ (or word ?_)) (1+ space))) ?=)
-     (1 font-lock-keyword-face)
-     (2 font-lock-function-name-face))
-
-    ;; Function definition
-    (,(rx symbol-start
-          (group (1+ (or word ?_))) (1+ space)
-          (group (1+ (or word ?_ space))) (1+ space) ?=)
-     (1 font-lock-function-name-face))
-
-    ;; Data constructors
-    (,(rx symbol-start
-          (group (char upper) (1+ (or word ?_)))
-          symbol-end)
-     (1 font-lock-type-face))
-
-    (,(rx (or digit symbol-start)
-          (group (or ?- ?+ ?%))
-          (or digit symbol-end))
-     (1 font-lock-variable-name-face))
-
-    (,(rx (not word) (group (or "->" "==" ?= "!=" ">=" "=<" ?> ?< ?=)))
-     (1 font-lock-variable-name-face))
-
-    ;; "Don't care"
-    (,(rx space (group ?_) space)
-     (1 font-lock-variable-name-face))
-
-    ;; BIFs
-    (,(rx symbol-start
-          (group "is_" (or "integer" "float" "atom" "bool"
-                           "list" "string" "chars" "pid" "binary"))
-          symbol-end)
-     (1 font-lock-builtin-face))))
+(defgroup alpaca nil
+  "Support for the alpaca programming language."
+  :link '(url-link :tag "Github" "https://github.com/alpaca-lang/alpaca-mode")
+  :group 'languages)
 
 ;;;###autoload
-(defun alpaca-mode ()
-  "Major mode for editing Alpaca files."
-  (interactive)
-  (kill-all-local-variables)
+(define-derived-mode alpaca-mode prog-mode "Alpaca"
+  "Major mode for editing Alpaca source code."
+  (setq-local indent-tabs-mode nil)
 
-  (let ((table (make-syntax-table)))
-    (modify-syntax-entry ?- ". 124b" table)
-    (modify-syntax-entry ?\n "> b" table)
-    (set-syntax-table table))
+  (when (boundp 'electric-indent-inhibit)
+    (setq-local electric-indent-inhibit t))
 
-  (setq major-mode 'alpaca-mode)
-  (set (make-local-variable 'font-lock-defaults)
-       '((alpaca-font-lock-keywords) nil nil))
-  (set (make-local-variable 'font-lock-keywords)
-       alpaca-font-lock-keywords)
+  (setq-local comment-start "--")
+  (setq-local comment-end "")
 
-  (set (make-local-variable 'comment-start) "--")
-  (set (make-local-variable 'comment-end) ""))
+  (turn-on-alpaca-font-lock)
+  (turn-on-alpaca-indent))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.alp\\'" . alpaca-mode))

--- a/alpaca-mode.el
+++ b/alpaca-mode.el
@@ -1,18 +1,17 @@
 ;;; alpaca-mode --- A major mode for the Alpaca language.
 
-;; Copyright (C) 2016 The Alpaca Community
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;; Author: Eric Bailey, Tyler Weir
 ;; Keywords: languages alpaca


### PR DESCRIPTION
Still need to know what to do about the license. elm-mode is gpl3 and the current alpaca-mode is apache2. No idea what, if anything, needs to be done to merge the two.

I also still haven't actually gone through the indentation code to remove what isn't needed from elm.