### PR TITLE
Add Cask support and fix some headers

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,0 +1,4 @@
+(source gnu)
+(source melpa)
+
+(package-file "alpaca-mode.el")

--- a/alpaca-mode.el
+++ b/alpaca-mode.el
@@ -1,4 +1,12 @@
-;;; alpaca-mode --- A major mode for the Alpaca language.
+;;; alpaca-mode.el --- A major mode for the Alpaca language.
+
+;; Copyright (C) 2016-2017 The Alpaca Community
+
+;; Author: Eric Bailey, Tyler Weir
+;; Keywords: languages
+;; Version: 0.1
+
+;; This file is not part of GNU Emacs.
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -12,9 +20,6 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-;; Author: Eric Bailey, Tyler Weir
-;; Keywords: languages alpaca
 
 ;;; Commentary:
 


### PR DESCRIPTION
This adds [Cask](http://cask.readthedocs.io/en/latest/) support and
package building support in general, mainly because I'm scared of
messing with load-paths.

`cask package` will now work and provide something you can install
with `M-x package-install-file`. Cask complained about a couple of
headers so I fixed them according to the
[manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers).